### PR TITLE
update to 1.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     modIncludeImplementation(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
 
     // Iris
-    modImplementation "net.coderbot.iris_mc1_17:iris:1.1.2-starline+"
+    modImplementation "net.coderbot.iris_mc1_17:iris:1.1.3-starline+"
 }
 
 if (project.use_third_party_mods) {


### PR DESCRIPTION
something I've noticed is the fact that it still requires 1.1.2 when iris is on 1.1.3 codeline